### PR TITLE
Solve missing stdint.h on I2C driver for AVR

### DIFF
--- a/drivers/avr/i2c_master.h
+++ b/drivers/avr/i2c_master.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include <stdint.h>
 
 #define I2C_READ 0x01
 #define I2C_WRITE 0x00


### PR DESCRIPTION
<!---
    For keyboard addition or changes, Vial will accept keyboards that implement "default" and "via" keymaps.
    For Vial-enabled keymaps please ensure that VIAL_INSECURE is not set.

    User keymaps (i.e. https://github.com/vial-kb/vial-qmk/tree/vial/users) will not be accepted at the moment.

    For other core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
